### PR TITLE
fix: always return array config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ function parsePackage(file: string): Record<string, string[]> {
     list = { defaults: list };
   }
   if (typeof list === 'string') {
-    list = { defaults: list.split(',').map((item) => item.trim()) };
+    list = parseConfig(list);
   }
   for (const i in list) {
     check(list[i]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,11 @@ function parsePackage(file: string): Record<string, string[]> {
     );
   }
   let list = config.browserslist;
-  if (Array.isArray(list) || typeof list === 'string') {
+  if (Array.isArray(list)) {
     list = { defaults: list };
+  }
+  if (typeof list === 'string') {
+    list = { defaults: list.split(',').map((item) => item.trim()) };
   }
   for (const i in list) {
     check(list[i]);

--- a/test/package-json-string/index.test.ts
+++ b/test/package-json-string/index.test.ts
@@ -3,5 +3,5 @@ import { test } from 'vitest';
 import { loadConfig } from '../../src';
 
 test('load string browserslist from package.json', () => {
-  expect(loadConfig({ path: __dirname })).toEqual('last 2 versions');
+  expect(loadConfig({ path: __dirname })).toEqual(['last 2 versions', '> 1%']);
 });

--- a/test/package-json-string/package.json
+++ b/test/package-json-string/package.json
@@ -2,5 +2,5 @@
   "name": "test-package-json-env",
   "private": true,
   "version": "0.0.1",
-  "browserslist": "last 2 versions"
+  "browserslist": "last 2 versions, > 1%"
 }


### PR DESCRIPTION
Use `parseConfig` to parse string config.